### PR TITLE
Allow model instances to access other models with names matching Groupify modules

### DIFF
--- a/lib/groupify/adapter/active_record.rb
+++ b/lib/groupify/adapter/active_record.rb
@@ -4,44 +4,46 @@ require 'set'
 # Groups and members
 module Groupify
   module ActiveRecord
-    extend ActiveSupport::Concern
-    
-    included do
-      # Define a scope that returns nothing.
-      # This is built into ActiveRecord 4, but not 3
-      unless self.class.respond_to? :none
-        def self.none
-          where(arel_table[:id].eq(nil).and(arel_table[:id].not_eq(nil)))
-        end
-      end
-    end
-    
-    module ClassMethods
-      def acts_as_group(opts = {})
-        include Groupify::ActiveRecord::Group
-
-        if (member_klass = opts.delete :default_members)
-          self.default_member_class = member_klass.to_s.classify.constantize
-        end
-        
-        if (member_klasses = opts.delete :members)
-          member_klasses.each do |member_klass|
-            has_members(member_klass)
+    module Adapter
+      extend ActiveSupport::Concern
+      
+      included do
+        # Define a scope that returns nothing.
+        # This is built into ActiveRecord 4, but not 3
+        unless self.class.respond_to? :none
+          def self.none
+            where(arel_table[:id].eq(nil).and(arel_table[:id].not_eq(nil)))
           end
         end
       end
       
-      def acts_as_group_member(opts = {})
-        @group_class_name = opts[:class_name] || 'Group'
-        include Groupify::ActiveRecord::GroupMember
-      end
-      
-      def acts_as_named_group_member(opts = {})
-        include Groupify::ActiveRecord::NamedGroupMember
-      end
+      module ClassMethods
+        def acts_as_group(opts = {})
+          include Groupify::ActiveRecord::Group
 
-      def acts_as_group_membership(opts = {})
-        include Groupify::ActiveRecord::GroupMembership
+          if (member_klass = opts.delete :default_members)
+            self.default_member_class = member_klass.to_s.classify.constantize
+          end
+          
+          if (member_klasses = opts.delete :members)
+            member_klasses.each do |member_klass|
+              has_members(member_klass)
+            end
+          end
+        end
+        
+        def acts_as_group_member(opts = {})
+          @group_class_name = opts[:class_name] || 'Group'
+          include Groupify::ActiveRecord::GroupMember
+        end
+        
+        def acts_as_named_group_member(opts = {})
+          include Groupify::ActiveRecord::NamedGroupMember
+        end
+
+        def acts_as_group_membership(opts = {})
+          include Groupify::ActiveRecord::GroupMembership
+        end
       end
     end
 
@@ -325,4 +327,4 @@ module Groupify
   end
 end
 
-ActiveRecord::Base.send :include, Groupify::ActiveRecord
+ActiveRecord::Base.send :include, Groupify::ActiveRecord::Adapter

--- a/lib/groupify/adapter/mongoid.rb
+++ b/lib/groupify/adapter/mongoid.rb
@@ -4,34 +4,36 @@ require 'set'
 # Groups and members
 module Groupify
   module Mongoid
-    extend ActiveSupport::Concern
-    
-    included do
-      def none; where(:id => nil); end
-    end
-    
-    module ClassMethods
-      def acts_as_group(opts = {})
-        include Groupify::Mongoid::Group
-        
-        if (member_klass = opts.delete :default_members)
-          self.default_member_class = member_klass.to_s.classify.constantize
-        end
-        
-        if (member_klasses = opts.delete :members)
-          member_klasses.each do |member_klass|
-            has_members(member_klass)
+    module Adapter
+      extend ActiveSupport::Concern
+      
+      included do
+        def none; where(:id => nil); end
+      end
+      
+      module ClassMethods
+        def acts_as_group(opts = {})
+          include Groupify::Mongoid::Group
+          
+          if (member_klass = opts.delete :default_members)
+            self.default_member_class = member_klass.to_s.classify.constantize
+          end
+          
+          if (member_klasses = opts.delete :members)
+            member_klasses.each do |member_klass|
+              has_members(member_klass)
+            end
           end
         end
-      end
-      
-      def acts_as_group_member(opts = {})
-        @group_class_name = opts[:class_name] || 'Group'
-        include Groupify::Mongoid::GroupMember
-      end
-      
-      def acts_as_named_group_member(opts = {})
-        include Groupify::Mongoid::NamedGroupMember
+        
+        def acts_as_group_member(opts = {})
+          @group_class_name = opts[:class_name] || 'Group'
+          include Groupify::Mongoid::GroupMember
+        end
+        
+        def acts_as_named_group_member(opts = {})
+          include Groupify::Mongoid::NamedGroupMember
+        end
       end
     end
 
@@ -249,4 +251,4 @@ module Groupify
   end
 end
 
-Mongoid::Document.send :include, Groupify::Mongoid
+Mongoid::Document.send :include, Groupify::Mongoid::Adapter


### PR DESCRIPTION
Hey, thanks for writing this gem.  Let me explain the issue I ran into.  Given this setup:

``` ruby
class Group < ActiveRecord::Base  
  acts_as_group :members => [:users], :default_members => :users
end

class User < ActiveRecord::Base
  acts_as_group_member
  acts_as_named_group_member
end

class GroupMembership < ActiveRecord::Base  
  acts_as_group_membership
end

class SomeOtherARModel < ActiveRecord::Base
end

class PlainOldRubyObject
end
```

Instances of any of the first four classes can't access the Group or GroupMembership class, while PlainOldRubyObject instances can.  You can test this in the console:

``` irb
>> Group.new.instance_eval('Group')
=> Groupify::ActiveRecord::Group

>> User.new.instance_eval('Group')
=> Groupify::ActiveRecord::Group

>> GroupMembership.new.instance_eval('Group')
=> Groupify::ActiveRecord::Group

>> SomeOtherARModel.new.instance_eval('Group')
=> Groupify::ActiveRecord::Group

>> PlainOldRubyObject.new.instance_eval('Group')
=> Group(id: integer, type: string)
```

To fix this, all I did was wrap the `included` block and the ClassMethods module inside a module called Base and then have ActiveRecord::Base include just it instead of all the Groupify modules.  Now, running all of those commands returns the Group class and not the Groupify module. 

Let me know what you think, or if you want me to change anything. 
