### PR TITLE
Fixed bug that occurs when using namespaced Models

### DIFF
--- a/lib/groupify/adapter/active_record/group.rb
+++ b/lib/groupify/adapter/active_record/group.rb
@@ -138,7 +138,7 @@ module Groupify
         end
 
         def define_member_association(member_klass, association_name = nil)
-          association_name ||= member_klass.name.to_s.pluralize.underscore.to_sym
+          association_name ||= member_klass.model_name.plural.to_sym
           source_type = member_klass.base_class
 
           if ActiveSupport::VERSION::MAJOR > 3


### PR DESCRIPTION
    association_name ||= member_klass.name.to_s.pluralize.underscore.to_sym
was causing methods with slashes ("/") to be defined if the class name was namespaced

For example if you were registering a group via:

    #CoolModule::Group
    groupify :group, members: [ 'cool_module/users', 'cool_module/admins], default_members: 'cool_module/users'

Groupify would be trying to define the following method which would fail:

    #incorrect way causing failure
    def cool_module/users
       #implementation
    end

Instead of:

    #correct way
    def cool_module_users
       #implementation
    end

My change to using:

    association_name ||= member_klass.model_name.plural.to_sym

fixes this.

