### PR TITLE
Fixes the `member_ids=` auto generated method on groups

### DIFF
--- a/lib/groupify/adapter/active_record/group.rb
+++ b/lib/groupify/adapter/active_record/group.rb
@@ -17,6 +17,7 @@ module Groupify
         @member_klasses ||= Set.new
         has_many :group_memberships,
                  dependent: :destroy,
+                 as: :group,
                  class_name: Groupify.group_membership_class_name
 
       end


### PR DESCRIPTION
Without the polymorphic option, the group memberships were lacking a group_type

Fixes #33