### PR TITLE
Split group memberships

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+gem_groupify

--- a/lib/groupify/adapter/active_record/named_group_collection.rb
+++ b/lib/groupify/adapter/active_record/named_group_collection.rb
@@ -4,7 +4,7 @@ module Groupify
     class NamedGroupCollection < Set
       def initialize(member)
         @member = member
-        @named_group_memberships = member.group_memberships.named
+        @named_group_memberships = member.group_memberships_as_member.named
         @group_names = @named_group_memberships.pluck(:group_name).map(&:to_sym)
         super(@group_names)
       end
@@ -14,18 +14,18 @@ module Groupify
         membership_type = opts[:as]
 
         if @member.new_record?
-          @member.group_memberships.build(group_name: named_group, membership_type: nil)
+          @member.group_memberships_as_member.build(group_name: named_group, membership_type: nil)
         else
           @member.transaction do
-            @member.group_memberships.where(group_name: named_group, membership_type: nil).first_or_create!
+            @member.group_memberships_as_member.where(group_name: named_group, membership_type: nil).first_or_create!
           end
         end
 
         if membership_type
           if @member.new_record?
-            @member.group_memberships.build(group_name: named_group, membership_type: membership_type)
+            @member.group_memberships_as_member.build(group_name: named_group, membership_type: membership_type)
           else
-            @member.group_memberships.where(group_name: named_group, membership_type: membership_type).first_or_create!
+            @member.group_memberships_as_member.where(group_name: named_group, membership_type: membership_type).first_or_create!
           end
         end
 

--- a/lib/groupify/adapter/active_record/named_group_member.rb
+++ b/lib/groupify/adapter/active_record/named_group_member.rb
@@ -13,8 +13,8 @@ module Groupify
       extend ActiveSupport::Concern
 
       included do
-        unless respond_to?(:group_memberships)
-          has_many :group_memberships,
+        unless respond_to?(:group_memberships_as_member)
+          has_many :group_memberships_as_member,
                    as: :member,
                    autosave: true,
                    dependent: :destroy,
@@ -63,30 +63,30 @@ module Groupify
 
       module ClassMethods
         def as(membership_type)
-          joins(:group_memberships).where(group_memberships: {membership_type: membership_type})
+          joins(:group_memberships_as_member).where(group_memberships: {membership_type: membership_type})
         end
 
         def in_named_group(named_group)
           return none unless named_group.present?
 
-          joins(:group_memberships).where(group_memberships: {group_name: named_group}).uniq
+          joins(:group_memberships_as_member).where(group_memberships: {group_name: named_group}).uniq
         end
 
         def in_any_named_group(*named_groups)
           named_groups.flatten!
           return none unless named_groups.present?
 
-          joins(:group_memberships).where(group_memberships: {group_name: named_groups.flatten}).uniq
+          joins(:group_memberships_as_member).where(group_memberships: {group_name: named_groups.flatten}).uniq
         end
 
         def in_all_named_groups(*named_groups)
           named_groups.flatten!
           return none unless named_groups.present?
 
-          joins(:group_memberships).
+          joins(:group_memberships_as_member).
               group("#{quoted_table_name}.#{connection.quote_column_name('id')}").
               where(:group_memberships => {:group_name => named_groups}).
-              having("COUNT(DISTINCT #{reflect_on_association(:group_memberships).klass.quoted_table_name}.#{connection.quote_column_name('group_name')}) = ?", named_groups.count).
+              having("COUNT(DISTINCT #{reflect_on_association(:group_memberships_as_member).klass.quoted_table_name}.#{connection.quote_column_name('group_name')}) = ?", named_groups.count).
               uniq
         end
 
@@ -94,9 +94,9 @@ module Groupify
           named_groups.flatten!
           return none unless named_groups.present?
 
-          joins(:group_memberships).
+          joins(:group_memberships_as_member).
               group("#{quoted_table_name}.#{connection.quote_column_name('id')}").
-              having("COUNT(DISTINCT #{reflect_on_association(:group_memberships).klass.quoted_table_name}.#{connection.quote_column_name('group_name')}) = ?", named_groups.count).
+              having("COUNT(DISTINCT #{reflect_on_association(:group_memberships_as_member).klass.quoted_table_name}.#{connection.quote_column_name('group_name')}) = ?", named_groups.count).
               uniq
         end
 


### PR DESCRIPTION
New associations are:

```ruby
has_many :group_memberships_as_member
has_many :group_memberships_as_group
```

This allows a model to be both a group and a group member at the same
time.

Breaks backwards compatibility with 0.x versions and differs in
exposed interface from mongoid adapter.

Fixes dwbutler/groupify#45