### PR TITLE
Fix member association filtering

### DIFF
--- a/lib/groupify/adapter/active_record/group.rb
+++ b/lib/groupify/adapter/active_record/group.rb
@@ -145,23 +145,7 @@ module Groupify
 
         def define_member_association(member_klass, association_name = nil)
           association_name ||= member_klass.model_name.plural.to_sym
-          source_type = member_klass.base_class
-
-          if ActiveSupport::VERSION::MAJOR > 3
-            has_many association_name,
-                     ->{ uniq },
-                     through: :group_memberships_as_group,
-                     source: :member,
-                     source_type: source_type,
-                     extend: MemberAssociationExtensions
-          else
-            has_many association_name,
-                     uniq: true,
-                     through: :group_memberships_as_group,
-                     source: :member,
-                     source_type: source_type,
-                     extend: MemberAssociationExtensions
-          end
+          has_many association_name, *association_options(member_klass)
 
           define_method(association_name) do |*args|
             opts = args.extract_options!
@@ -171,6 +155,37 @@ module Groupify
             else
               super()
             end
+          end
+        end
+
+        def association_options(member_klass)
+          source_type = member_klass.base_class
+          using_sti = (member_klass.base_class != member_klass)
+
+          if ActiveSupport::VERSION::MAJOR > 3
+            filter = using_sti ? -> { uniq.where(type: member_klass.name.to_s) } : -> { uniq }
+
+            [
+              filter,
+              {
+                through: :group_memberships_as_group,
+                source: :member,
+                source_type: source_type,
+                extend: MemberAssociationExtensions
+              }
+            ]
+          else
+            options = {
+              uniq: true,
+              through: :group_memberships_as_group,
+              source: :member,
+              source_type: source_type,
+              extend: MemberAssociationExtensions
+            }
+            if using_sti
+              options.merge(conditions: { type: member_klass.name.to_s })
+            end
+            [options]
           end
         end
       end

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -186,6 +186,15 @@ describe Groupify::ActiveRecord do
         expect(group.namespaced_members).to include(namespaced_member)
       end
 
+      it "adds a model using STI to a group" do
+        manager = Manager.create!
+        user = User.create!
+        organization = Organization.create!
+        organization.add(manager, user)
+        expect(organization.users).to match_array [user, manager]
+        expect(organization.managers).to match_array [manager]
+      end
+
       it "adds multiple members to a group" do
         group.add(user, widget)
         expect(group.users).to include(user)


### PR DESCRIPTION
When defining an association through a join table to a model using single table inheritance, ActiveRecord will always store the base class name in the join table. This allows the base class to always be correctly queried, but makes it challenging to correctly define an association that only returns a subclass.

Groupify groups define member associations using the `source_type` set correctly to the base class, but this returns all members of the base class instead of filtering to only members of the subclass. This fixes the issue by adding a filtering condition to the association on the `type` column, but only if STI is detected.