### PR TITLE
Add timestamps to groups table in migration generator template

### DIFF
--- a/lib/generators/groupify/active_record/migration/templates/migration.rb
+++ b/lib/generators/groupify/active_record/migration/templates/migration.rb
@@ -2,6 +2,8 @@ class GroupifyMigration < ActiveRecord::Migration
   def change
     create_table :groups do |t|
       t.string     :type
+
+      t.timestamps
     end
 
     create_table :group_memberships do |t|


### PR DESCRIPTION
Default Group memberships table has rails default timestamps included but groups table does not.

This should fix the discrepancy.
