### PR TITLE
Add the `has_member` and `has_group` association helpers to specify model class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Set up your member models:
 ```ruby
 class User
   include Mongoid::Document
-  
+
   groupify :group_member
   groupify :named_group_member
 end
@@ -130,6 +130,10 @@ Example:
 ```ruby
 class Organization < Group
   has_members :offices, :equipment
+end
+
+class Organization < Group
+  has_members users: 'CustomUserClass', teams: 'CustomTeamClass'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -132,13 +132,42 @@ class Organization < Group
   has_members :offices, :equipment
 end
 
-class Organization2 < Group
+class InternationalOrganization < Organization
   has_member :offices, class_name: 'CustomOfficeClass'
   has_member :equipment, class_name: 'CustomEquipmentClass'
 end
 ```
 
 Mongoid works the same way by creating Mongoid relations.
+
+##### Group Associations on Member (ActiveRecord only)
+
+Your member class can be configured to create associations for each expected group type.
+For example, let's say that your member class will have multiple types of organizations as groups.
+The following configuration adds `organizations` and `international_organizations` associations
+on the member model:
+
+```ruby
+class Group < ActiveRecord::Base
+  groupify :group, members: [:users, :assignments], default_members: :users
+end
+
+class Organization < Group
+  has_members :offices, :equipment
+end
+
+class InternationalOrganization < Organization
+end
+
+class Member < ActiveRecord::Base
+  groupify :group_member
+
+  has_group :organizations, class_name: 'Organization'
+  has_group :international_organizations, class_name: 'InternationalOrganization'
+end
+```
+
+Mongoid does not support the `has_group` helper method.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,9 @@ class Organization < Group
   has_members :offices, :equipment
 end
 
-class Organization < Group
-  has_members users: 'CustomUserClass', teams: 'CustomTeamClass'
+class Organization2 < Group
+  has_member :offices, class_name: 'CustomOfficeClass'
+  has_member :equipment, class_name: 'CustomEquipmentClass'
 end
 ```
 

--- a/lib/groupify/adapter/active_record/group.rb
+++ b/lib/groupify/adapter/active_record/group.rb
@@ -69,20 +69,23 @@ module Groupify
 
         # Define which classes are members of this group
         def has_members(*names)
-          klass_map = names.last.is_a?(Hash) ? names.pop : {}
-          klass_map = names.inject({}){ |hash, name| hash.merge(name => nil) }.merge(klass_map)
-
-          klass_map.each do |name, klass_name|
-            if klass_name.nil?
-              klass = name.to_s.classify.constantize
-              association_name = name.is_a?(Symbol) ? name : klass.model_name.plural.to_sym
-            else
-              klass = klass_name.to_s.classify.constantize
-              association_name = name.to_sym
-            end
-
-            register(klass, association_name)
+          Array.wrap(names.flatten).each do |name|
+            has_member name
           end
+        end
+
+        def has_member(name, options = {})
+          klass_name = options[:class_name]
+
+          if klass_name.nil?
+            klass = name.to_s.classify.constantize
+            association_name = name.is_a?(Symbol) ? name : klass.model_name.plural.to_sym
+          else
+            klass = klass_name.to_s.classify.constantize
+            association_name = name.to_sym
+          end
+
+          register(klass, association_name)
         end
 
         # Merge two groups. The members of the source become members of the destination, and the source is destroyed.

--- a/lib/groupify/adapter/active_record/group.rb
+++ b/lib/groupify/adapter/active_record/group.rb
@@ -69,9 +69,19 @@ module Groupify
 
         # Define which classes are members of this group
         def has_members(*names)
-          Array.wrap(names.flatten).each do |name|
-            klass = name.to_s.classify.constantize
-            register(klass)
+          klass_map = names.last.is_a?(Hash) ? names.pop : {}
+          klass_map = names.inject({}){ |hash, name| hash.merge(name => nil) }.merge(klass_map)
+
+          klass_map.each do |name, klass_name|
+            if klass_name.nil?
+              klass = name.to_s.classify.constantize
+              association_name = name.is_a?(Symbol) ? name : klass.model_name.plural.to_sym
+            else
+              klass = klass_name.to_s.classify.constantize
+              association_name = name.to_sym
+            end
+
+            register(klass, association_name)
           end
         end
 
@@ -93,10 +103,10 @@ module Groupify
 
         protected
 
-        def register(member_klass)
+        def register(member_klass, association_name = nil)
           (@member_klasses ||= Set.new) << member_klass
 
-          associate_member_class(member_klass)
+          associate_member_class(member_klass, association_name)
 
           member_klass
         end
@@ -135,8 +145,8 @@ module Groupify
           end
         end
 
-        def associate_member_class(member_klass)
-          define_member_association(member_klass)
+        def associate_member_class(member_klass, association_name = nil)
+          define_member_association(member_klass, association_name)
 
           if member_klass == default_member_class
             define_member_association(member_klass, :members)

--- a/lib/groupify/adapter/active_record/group_member.rb
+++ b/lib/groupify/adapter/active_record/group_member.rb
@@ -21,11 +21,7 @@ module Groupify
                    class_name: Groupify.group_membership_class_name
         end
 
-        has_many :groups, ->{ distinct },
-                 through: :group_memberships_as_member,
-                 as: :group,
-                 source_type: @group_class_name,
-                 extend: GroupAssociationExtensions
+        has_group :groups
       end
 
       module GroupAssociationExtensions
@@ -136,6 +132,15 @@ module Groupify
 
         def shares_any_group(other)
           in_any_group(other.groups)
+        end
+
+        def has_group(name, options = {})
+          has_many name.to_sym, ->{ distinct }, {
+            through: :group_memberships_as_member,
+            source: :group,
+            source_type: @group_class_name,
+            extend: GroupAssociationExtensions
+          }.merge(options.slice :class_name)
         end
 
       end

--- a/lib/groupify/adapter/mongoid/group.rb
+++ b/lib/groupify/adapter/mongoid/group.rb
@@ -66,20 +66,23 @@ module Groupify
 
         # Define which classes are members of this group
         def has_members(*names)
-          klass_map = names.last.is_a?(Hash) ? names.pop : {}
-          klass_map = names.inject({}){ |hash, name| hash.merge(name => nil) }.merge(klass_map)
-
-          klass_map.each do |name, klass_name|
-            if klass_name.nil?
-              klass = name.to_s.classify.constantize
-              association_name = name.is_a?(Symbol) ? name : klass.model_name.plural.to_sym
-            else
-              klass = klass_name.to_s.classify.constantize
-              association_name = name.to_sym
-            end
-
-            register(klass, association_name)
+          Array.wrap(names.flatten).each do |name|
+            has_member name
           end
+        end
+
+        def has_member(name, options = {})
+          klass_name = options[:class_name]
+
+          if klass_name.nil?
+            klass = name.to_s.classify.constantize
+            association_name = name.is_a?(Symbol) ? name : klass.model_name.plural.to_sym
+          else
+            klass = klass_name.to_s.classify.constantize
+            association_name = name.to_sym
+          end
+
+          register(klass, association_name)
         end
 
         # Merge two groups. The members of the source become members of the destination, and the source is destroyed.
@@ -115,7 +118,7 @@ module Groupify
           (@member_klasses ||= Set.new) << member_klass
 
           associate_member_class(member_klass, association_name)
-          
+
           member_klass
         end
 


### PR DESCRIPTION
We wanted to create a `users` association with a `CustomUser` class. We added the option to use `has_member :users, class_name: 'CustomUser'`, so you can specify the class for specific associations. This is backwards compatible with just passing in association names to `has_members`.

I *think* that the only change that's missing from Mongoid is `default_members: true` option for `has_member`