### PR TITLE
Gracefully handle missing group

### DIFF
--- a/lib/groupify/adapter/active_record/group_member.rb
+++ b/lib/groupify/adapter/active_record/group_member.rb
@@ -58,6 +58,7 @@ module Groupify
       end
 
       def in_group?(group, opts={})
+        return false unless group.present?
         criteria = {group_id: group.id}
 
         if opts[:as]

--- a/lib/groupify/adapter/mongoid/group_member.rb
+++ b/lib/groupify/adapter/mongoid/group_member.rb
@@ -71,6 +71,7 @@ module Groupify
       end
 
       def in_group?(group, opts={})
+        return false unless group.present?
         groups.as(opts[:as]).include?(group)
       end
 

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -299,6 +299,10 @@ describe Groupify::ActiveRecord do
         expect(user.shares_any_group?(user2)).to be true
         expect(User.shares_any_group(user).to_a).to include(user2)
       end
+
+      it "gracefully handles missing groups" do
+        expect(user.in_group?(nil)).to be false
+      end
     end
 
     context 'when merging groups' do

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -243,6 +243,10 @@ describe Groupify::Mongoid do
         expect(user.shares_any_group?(user2)).to be true
         expect(MongoidUser.shares_any_group(user).to_a).to include(user2)
       end
+
+      it "gracefully handles missing groups" do
+        expect(user.in_group?(nil)).to be false
+      end
     end
 
     context 'when merging' do


### PR DESCRIPTION
When calling `#in_group?` with a group that doesn’t exist (e.g. when passing `nil`), correctly return `false`.